### PR TITLE
Bugfix: remove isSerializable

### DIFF
--- a/FSConfig.cpp
+++ b/FSConfig.cpp
@@ -72,20 +72,7 @@ void saveConfig() {
   for (uint8_t i=0; i < sensorList.size(); i++) {
     tmpSensorInfo = sensorList.get(i);
     JsonObject& tmpSens = jsonSensors.createNestedObject();
-    if (tmpSensorInfo->isSerializable()) {
-      tmpSensorInfo->toJson(tmpSens);
-    } else {
-      tmpSens["address"] = tmpSensorInfo->address;
-      tmpSens["type"] = (int)tmpSensorInfo->type;
-
-      JsonArray& jsonPaths = tmpSens.createNestedArray("signalKPaths");
-      for (int x=0;x<MAX_SENSOR_ATTRIBUTES; x++) {
-        if (strcmp(tmpSensorInfo->attrName[x].c_str(), "") == 0 ) {
-          break; //no more attributes
-        }
-        jsonPaths.add(tmpSensorInfo->signalKPath[x]);
-      }
-    }
+    tmpSensorInfo->toJson(tmpSens);
   }
 
   uint32_t oneWireReadDelay = getOneWireReadDelay();

--- a/digitalIn.cpp
+++ b/digitalIn.cpp
@@ -32,10 +32,6 @@ DigitalInSensorInfo::DigitalInSensorInfo(String addr,
   isUpdated = false;
 }
 
-bool DigitalInSensorInfo::isSerializable() {
-  return true;
-}
-
 DigitalInSensorInfo *DigitalInSensorInfo::fromJson(JsonObject &jsonSens) {
   return new DigitalInSensorInfo(
     jsonSens["address"],

--- a/digitalIn.h
+++ b/digitalIn.h
@@ -15,8 +15,6 @@ class DigitalInSensorInfo : public SensorInfo {
 
     static DigitalInSensorInfo *fromJson(JsonObject &jsonSens);
     void toJson(JsonObject &jsonSens);
-
-    bool isSerializable();
 };
 
 void setupDigitalIn(bool &need_save);

--- a/mpu9250.cpp
+++ b/mpu9250.cpp
@@ -48,10 +48,6 @@ MPU9250SensorInfo::MPU9250SensorInfo(String addr, String path1, String path2,
   isUpdated = false;
 }
 
-bool MPU9250SensorInfo::isSerializable() {
-  return true;
-}
-
 MPU9250SensorInfo *MPU9250SensorInfo::fromJson(JsonObject &jsonSens) {
   return new MPU9250SensorInfo(
     jsonSens["address"],

--- a/mpu9250.h
+++ b/mpu9250.h
@@ -17,8 +17,6 @@ class MPU9250SensorInfo : public SensorInfo {
 
     static MPU9250SensorInfo *fromJson(JsonObject &jsonSens);
     void toJson(JsonObject &jsonSens);
-
-    bool isSerializable();
 };
 
 bool configureMPU9250();

--- a/oneWire.cpp
+++ b/oneWire.cpp
@@ -32,10 +32,6 @@ OneWireSensorInfo::OneWireSensorInfo(String addr, String path) {
   isUpdated = false;
 }
 
-bool OneWireSensorInfo::isSerializable() {
-  return true;
-}
-
 OneWireSensorInfo *OneWireSensorInfo::fromJson(JsonObject &jsonSens) {
   Serial.println("OneWireSensorInfo::fromJson");
   return new OneWireSensorInfo(

--- a/oneWire.h
+++ b/oneWire.h
@@ -11,9 +11,6 @@ class OneWireSensorInfo : public SensorInfo {
 
     static OneWireSensorInfo *fromJson(JsonObject &jsonSens);
     void toJson(JsonObject &jsonSens);
-    
-
-    bool isSerializable();
 };
 
 void setup1Wire(bool&);

--- a/sht30.cpp
+++ b/sht30.cpp
@@ -32,10 +32,6 @@ SHT30SensorInfo::SHT30SensorInfo(String addr, String path1, String path2) {
   isUpdated = false;
 }
 
-bool SHT30SensorInfo::isSerializable() {
-  return true;
-}
-
 SHT30SensorInfo *SHT30SensorInfo::fromJson(JsonObject &jsonSens) {
   return new SHT30SensorInfo(
     jsonSens["address"],

--- a/sht30.h
+++ b/sht30.h
@@ -14,8 +14,6 @@ class SHT30SensorInfo : public SensorInfo {
 
     static SHT30SensorInfo *fromJson(JsonObject &jsonSens);
     void toJson(JsonObject &jsonSens);
-
-    bool isSerializable();
 };
 
 

--- a/sigksens.cpp
+++ b/sigksens.cpp
@@ -20,10 +20,3 @@ void parseBytes(const char* str, char sep, byte* bytes, int maxBytes, int base) 
       str++;                                // Point to next character after separator
   }
 }
-
-// SensorInfo
-
-bool SensorInfo::isSerializable() {
-    // default SensorInfo object can't serialize itself
-    return false;
-}

--- a/sigksens.h
+++ b/sigksens.h
@@ -34,7 +34,6 @@ class SensorInfo {
     SensorType type;
     bool isUpdated;
 
-    bool isSerializable();
     static SensorInfo *fromJson(JsonObject&);
     virtual void toJson(JsonObject&) = 0;
 };

--- a/systemHz.cpp
+++ b/systemHz.cpp
@@ -32,10 +32,6 @@ SystemHzSensorInfo::SystemHzSensorInfo(String addr,
   isUpdated = false;
 }
 
-bool SystemHzSensorInfo::isSerializable() {
-  return true;
-}
-
 SystemHzSensorInfo *SystemHzSensorInfo::fromJson(JsonObject &jsonSens) {
   return new SystemHzSensorInfo(
     jsonSens["address"],

--- a/systemHz.h
+++ b/systemHz.h
@@ -15,8 +15,6 @@ class SystemHzSensorInfo : public SensorInfo {
 
     static SystemHzSensorInfo *fromJson(JsonObject &jsonSens);
     void toJson(JsonObject &jsonSens);
-
-    bool isSerializable();
 };
 
 


### PR DESCRIPTION
The actual bug was a user error: I should've defined the base class `isSerializable` function `virtual`, otherwise the redefined inherited class functions are never called. However, `isSerializable` was only needed during the refactoring work and was already obsolete because the `*SensorInfo` classes always have `toJson()` defined. I just removed it altogether.