### PR TITLE
Global timer

### DIFF
--- a/FSConfig.cpp
+++ b/FSConfig.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 #include "systemHz.h"
 #include "sigksens.h"
+#include "timer.h"
 
 /*----------------------------------------------------------------------------
 ------------------------------------------------------------------------------
@@ -86,17 +87,17 @@ void saveConfig() {
     si->toJson(jsonSensors.createNestedObject());
   });
 
+  //Timers
+  json["deltaTimer"] = getDeltaDelay();
+
   #ifdef ENABLE_ONEWIRE
   uint32_t oneWireReadDelay = getOneWireReadDelay();
   
-  //Timers
+  
   json["oneWireReadDelay"] = oneWireReadDelay;
   #endif
   #ifdef ENABLE_SHT30
   json["sensorSHTReadDelay"] = getSensorSHTReadDelay();
-  #endif
-  #ifdef ENABLE_MPU
-  json["updateMPUDelay"] = getUpdateMPUDelay();
   #endif
   #ifdef ENABLE_ADS1115
   json["readADSDelay"] = getReadADSDelay();
@@ -158,16 +159,13 @@ void loadConfig() {
         }
 
         //Timers
-
+        setDeltaDelay(json["deltaTimer"]);
         #ifdef ENABLE_ONEWIRE
         uint32_t oneWireReadDelay = json["oneWireReadDelay"];
         setOneWireReadDelay(oneWireReadDelay);
         #endif
         #ifdef ENABLE_SHT30
         setSHTReadDelay(json["sensorSHTReadDelay"]);
-        #endif
-        #ifdef ENABLE_MPU
-        setMPUUpdateDelay(json["updateMPUDelay"]);
         #endif
         #ifdef ENABLE_ADS1115
         setADSReadDelay(json["readADSDelay"]);

--- a/FSConfig.cpp
+++ b/FSConfig.cpp
@@ -98,7 +98,6 @@ void saveConfig() {
   #endif
   #ifdef ENABLE_ADS1115
   json["readADSDelay"] = getReadADSDelay();
-  json["updateADSDelay"] = getUpdateADSDelay();
   #endif
   #ifdef ENABLE_DIGITALIN
   json["updateDigitalInDelay"] = getUpdateDigitalInDelay();
@@ -163,7 +162,6 @@ void loadConfig() {
         #endif
         #ifdef ENABLE_ADS1115
         setADSReadDelay(json["readADSDelay"]);
-        setADSUpdateDelay(json["updateADSDelay"]);
         #endif
         #ifdef ENABLE_DIGITALIN
         setDigitalInUpdateDelay(json["updateDigitalInDelay"]);

--- a/FSConfig.cpp
+++ b/FSConfig.cpp
@@ -89,10 +89,6 @@ void saveConfig() {
 
   //Timers
   json["deltaTimer"] = getDeltaDelay();
-
-  #ifdef ENABLE_ONEWIRE
-  json["oneWireReadDelay"] = getOneWireReadDelay();
-  #endif
   #ifdef ENABLE_ADS1115
   json["readADSDelay"] = getReadADSDelay();
   #endif
@@ -150,10 +146,6 @@ void loadConfig() {
 
         //Timers
         setDeltaDelay(json["deltaTimer"]);
-        #ifdef ENABLE_ONEWIRE
-        uint32_t oneWireReadDelay = json["oneWireReadDelay"];
-        setOneWireReadDelay(oneWireReadDelay);
-        #endif
         #ifdef ENABLE_ADS1115
         setADSReadDelay(json["readADSDelay"]);
         #endif

--- a/FSConfig.cpp
+++ b/FSConfig.cpp
@@ -91,16 +91,10 @@ void saveConfig() {
   json["deltaTimer"] = getDeltaDelay();
 
   #ifdef ENABLE_ONEWIRE
-  uint32_t oneWireReadDelay = getOneWireReadDelay();
-  
-  
-  json["oneWireReadDelay"] = oneWireReadDelay;
+  json["oneWireReadDelay"] = getOneWireReadDelay();
   #endif
   #ifdef ENABLE_ADS1115
   json["readADSDelay"] = getReadADSDelay();
-  #endif
-  #ifdef ENABLE_DIGITALIN
-  json["updateDigitalInDelay"] = getUpdateDigitalInDelay();
   #endif
   
   File configFile = SPIFFS.open("/config.json", "w");
@@ -162,9 +156,6 @@ void loadConfig() {
         #endif
         #ifdef ENABLE_ADS1115
         setADSReadDelay(json["readADSDelay"]);
-        #endif
-        #ifdef ENABLE_DIGITALIN
-        setDigitalInUpdateDelay(json["updateDigitalInDelay"]);
         #endif
       } else {
         Serial.println("failed to load json config");

--- a/FSConfig.cpp
+++ b/FSConfig.cpp
@@ -96,9 +96,6 @@ void saveConfig() {
   
   json["oneWireReadDelay"] = oneWireReadDelay;
   #endif
-  #ifdef ENABLE_SHT30
-  json["sensorSHTReadDelay"] = getSensorSHTReadDelay();
-  #endif
   #ifdef ENABLE_ADS1115
   json["readADSDelay"] = getReadADSDelay();
   json["updateADSDelay"] = getUpdateADSDelay();
@@ -163,9 +160,6 @@ void loadConfig() {
         #ifdef ENABLE_ONEWIRE
         uint32_t oneWireReadDelay = json["oneWireReadDelay"];
         setOneWireReadDelay(oneWireReadDelay);
-        #endif
-        #ifdef ENABLE_SHT30
-        setSHTReadDelay(json["sensorSHTReadDelay"]);
         #endif
         #ifdef ENABLE_ADS1115
         setADSReadDelay(json["readADSDelay"]);

--- a/SigkSens.ino
+++ b/SigkSens.ino
@@ -41,7 +41,7 @@
 #include "signalK.h"
 #include "httpd.h"
 #include "sigksens.h"
-
+#include "timer.h"
 
 /*---------------------------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
@@ -171,6 +171,8 @@ void setup() {
   #endif
   setupSystemHz(need_save);
   
+  setupTimers();
+
   if (need_save) {
     saveConfig();
   }
@@ -187,11 +189,16 @@ Main Loop!
 
 void loop() {
   bool need_save = false;
+  bool sendDelta = false;
   //device mgmt
   yield();           
   
+  // see if we're ready to send deltas
+  handleTimers(sendDelta);
+
+
   //Stuff here run's all the time
-  handleSystemHz();
+  handleSystemHz(sendDelta);
   #ifdef ENABLE_I2C
   handleI2C();
   #endif

--- a/SigkSens.ino
+++ b/SigkSens.ino
@@ -197,6 +197,7 @@ void loop() {
   handleTimers(sendDelta);
 
 
+
   //Stuff here run's all the time
   handleSystemHz(sendDelta);
   #ifdef ENABLE_I2C
@@ -204,24 +205,28 @@ void loop() {
   #endif
 
   mainLoopCount++;
-  
+
   //Stuff that runs  once every 1000 loops. (still many many times/sec)
-  if (mainLoopCount > 1000) {
+  if ((mainLoopCount > 1000) || sendDelta) {
+         if (sendDelta) {
+    Serial.println("d"); }
       #ifdef ENABLE_I2C
       handleI2C_slow(sendDelta);
       #endif
       #ifdef ENABLE_ONEWIRE
         handle1Wire(need_save);
       #endif
+      #ifdef ENABLE_DIGITALIN
+      handleDigitalIn(sendDelta);
+      #endif
+
       if (need_save) {
         saveConfig();
       }
   
       handleWebSocket();
       handleSignalK();
-      #ifdef ENABLE_DIGITALIN
-      handleDigitalIn();
-      #endif
+
       
       handleConfigReset(); 
       mainLoopCount = 0;

--- a/SigkSens.ino
+++ b/SigkSens.ino
@@ -200,7 +200,7 @@ void loop() {
   //Stuff here run's all the time
   handleSystemHz(sendDelta);
   #ifdef ENABLE_I2C
-  handleI2C();
+  handleI2C(sendDelta);
   #endif
 
   mainLoopCount++;

--- a/SigkSens.ino
+++ b/SigkSens.ino
@@ -208,7 +208,7 @@ void loop() {
   //Stuff that runs  once every 1000 loops. (still many many times/sec)
   if (mainLoopCount > 1000) {
       #ifdef ENABLE_I2C
-      handleI2C_slow();
+      handleI2C_slow(sendDelta);
       #endif
       #ifdef ENABLE_ONEWIRE
         handle1Wire(need_save);

--- a/SigkSens.ino
+++ b/SigkSens.ino
@@ -208,13 +208,11 @@ void loop() {
 
   //Stuff that runs  once every 1000 loops. (still many many times/sec)
   if ((mainLoopCount > 1000) || sendDelta) {
-         if (sendDelta) {
-    Serial.println("d"); }
       #ifdef ENABLE_I2C
       handleI2C_slow(sendDelta);
       #endif
       #ifdef ENABLE_ONEWIRE
-        handle1Wire(need_save);
+        handle1Wire(need_save, sendDelta);
       #endif
       #ifdef ENABLE_DIGITALIN
       handleDigitalIn(sendDelta);

--- a/ads1115.cpp
+++ b/ads1115.cpp
@@ -148,11 +148,6 @@ bool adsReadyRead = false;
 os_timer_t  adsReadTimer; // repeating timer that fires to read ADS
 
 
-uint32_t updateADSDelay = 1000;
-bool adsReadyUpdate = false;
-os_timer_t  adsUpdateSensorInfoTimer; // repeating timer that fires ever X/time
-
-
 //Running values. (we need to keep running value to reduce noise with exponential filter)
 
 float valueDiff_0_1 = 0;
@@ -169,9 +164,6 @@ void setupADS1115() {
   os_timer_setfn(&adsReadTimer, interruptReadADSS, NULL);
   os_timer_arm(&adsReadTimer, updateReadADSDelay, true);
 
-  // UpdateSensorInfo
-  os_timer_setfn(&adsUpdateSensorInfoTimer, interruptUpdateADSSensorInfo, NULL);
-  os_timer_arm(&adsUpdateSensorInfoTimer, updateADSDelay, true);
 
   // The ADC input range (or gain) can be changed via the following
   // functions, but be careful never to exceed VDD +0.3V max, or to
@@ -194,46 +186,25 @@ void setupADS1115() {
 }
 
 
-void handleADS1115() {
+void handleADS1115(bool &sendDelta) {
 
   if (adsReadyRead) {
     adsReadyRead = false;
     readADS1115();
   }
 
-  if (adsReadyUpdate) {
-    adsReadyUpdate = false;
+  if (sendDelta) {
     updateADS1115();
   }
   
 
 }
-
-
-void interruptUpdateADSSensorInfo(void *pArg) {
-  adsReadyUpdate = true;
-}
-
-
 void interruptReadADSS(void *pArg) {
   adsReadyRead = true;
 }
 
-
-uint32_t getUpdateADSDelay() { 
-  return updateADSDelay; 
-}
 uint32_t getReadADSDelay() { 
   return updateReadADSDelay; 
-}
-
-void setADSUpdateDelay(uint32_t newDelay) {
-  os_timer_disarm(&adsUpdateSensorInfoTimer);
-  Serial.print("Restarting ADS Update timer at: ");
-  Serial.print(newDelay);  
-  Serial.println("ms");
-  updateADSDelay = newDelay;
-  os_timer_arm(&adsUpdateSensorInfoTimer, updateADSDelay, true); 
 }
 
 void setADSReadDelay(uint32_t newDelay) {

--- a/ads1115.h
+++ b/ads1115.h
@@ -18,7 +18,7 @@ class ADSSensorInfo : public SensorInfo {
 };
 
 void setupADS1115();
-void handleADS1115();
+void handleADS1115(bool&);
 
 uint32_t getUpdateADSDelay();
 uint32_t getReadADSDelay();

--- a/bmp280.cpp
+++ b/bmp280.cpp
@@ -58,32 +58,12 @@ void BMP280SensorInfo::toJson(JsonObject &jsonSens) {
 }
 
 
-// timer delay
-uint32_t sensorBMP280ReadDelay = 5000; //ms between reading
-
-uint32_t getSensorBMP280ReadDelay() { return sensorBMP280ReadDelay; }
-
-os_timer_t  sensorBMP280PollTimer; // repeating timer that fires ever X/time to start poll cycle
-
-bool readytoPollBMP280 = false;
-
-void interruptBMP280Poll(void *pArg) {
-  readytoPollBMP280 = true;
-}
 
 // sensor object
 Adafruit_BMP280 bmp;
 
 void setupBMP280() {
-  // prepare BMP280 Timers 
-  os_timer_setfn(&sensorBMP280PollTimer, interruptBMP280Poll, NULL);
-
-  Serial.print("Starting BMP280 polling timer");
-  Serial.print(sensorBMP280ReadDelay);  
-  Serial.println("ms");
-  os_timer_arm(&sensorBMP280PollTimer, sensorBMP280ReadDelay, true); // TODO should probably confirm we actually have an BMP280 connected
-  
-  // this calls Wire.begin() again, but that shouldn't
+   // this calls Wire.begin() again, but that shouldn't
   // do any harm. Hopefully.
   bmp.begin();
 }
@@ -96,8 +76,6 @@ void readBMP280() {
   float Pa;
   float tempK;
   
-  readytoPollBMP280 = false; //reset interupt
-  
   Pa = bmp.readPressure();
   tempK = bmp.readTemperature() + 273.15;
 
@@ -109,20 +87,11 @@ void readBMP280() {
 }
 
 
-void handleBMP280() {
-  if (readytoPollBMP280){
+void handleBMP280(bool &sendDelta) {
+  if (sendDelta){
     digitalWrite(LED_BUILTIN, LOW);
     readBMP280();
     digitalWrite(LED_BUILTIN, HIGH);  
   }
 }
 
-
-void setBMP280ReadDelay(uint32_t newDelay) {
-  os_timer_disarm(&sensorBMP280PollTimer);
-  sensorBMP280ReadDelay = newDelay;
-  Serial.print("Restarting BMP280 polling timer at: ");
-  Serial.print(newDelay);  
-  Serial.println("ms");  
-  os_timer_arm(&sensorBMP280PollTimer, sensorBMP280ReadDelay, true);  
-}

--- a/bmp280.h
+++ b/bmp280.h
@@ -18,9 +18,6 @@ class BMP280SensorInfo : public SensorInfo {
 
 
 void setupBMP280();
-void handleBMP280();
-
-uint32_t getSensorBMP280ReadDelay();
-void setBMP280ReadDelay(uint32_t newDelay);
+void handleBMP280(bool&);
 
 #endif

--- a/digitalIn.cpp
+++ b/digitalIn.cpp
@@ -147,6 +147,7 @@ void setupDigitalIn(bool &need_save) {
 
 void handleDigitalIn(bool &sendDelta) {
   //Check if periodic update ready
+  if (sendDelta) {
     for (int index=0;index<(sizeof(digitalPins)/sizeof(digitalPins[0])); index++) {
       digitalUpdateReady[index] = true; //set them all to true  
     }

--- a/digitalIn.h
+++ b/digitalIn.h
@@ -17,14 +17,11 @@ class DigitalInSensorInfo : public SensorInfo {
 };
 
 void setupDigitalIn(bool &need_save);
-void handleDigitalIn();
+void handleDigitalIn(bool &sendDelta);
 void initializeDigitalPin(uint8_t index, bool &need_save);
 
 void updateDigitalInState(uint8_t index);
 void updateDigitalInPeriodic(uint8_t index);
-
-void setDigitalInUpdateDelay(uint32_t newDelay);
-uint32_t getUpdateDigitalInDelay();
 
 void getDigitalPinName(uint8_t index, char *dstCharArr);
 

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -228,9 +228,6 @@ void httpGetSensorInfo(AsyncWebServerRequest *request) {
   #ifdef ENABLE_ONEWIRE
   timers["oneWire"] = getOneWireReadDelay();
   #endif
-  #ifdef ENABLE_SHT30
-  timers["sht30"] = getSensorSHTReadDelay();
-  #endif
   #ifdef ENABLE_ADS1115
   timers["ads1115Read"] = getReadADSDelay();
   timers["ads1115Update"] = getUpdateADSDelay();
@@ -342,12 +339,6 @@ void httpSetTimerDelay(AsyncWebServerRequest *request) {
     else if (strcmp(timer, "oneWire") == 0) {
       ok = true;
       setOneWireReadDelay(newDelay);
-    }
-    #endif
-    #ifdef ENABLE_SHT30
-    else if (strcmp(timer, "sht30") == 0) {
-      ok = true;
-      setSHTReadDelay(newDelay);
     }
     #endif
     #ifdef ENABLE_ADS1115

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -231,9 +231,7 @@ void httpGetSensorInfo(AsyncWebServerRequest *request) {
   #ifdef ENABLE_ADS1115
   timers["ads1115Read"] = getReadADSDelay();
   #endif
-  #ifdef ENABLE_DIGITALIN
-  timers["digitalIn"] = getUpdateDigitalInDelay();
-  #endif
+
 
   //Sensors
   JsonArray& sensorArr = json.createNestedArray("sensors");
@@ -346,13 +344,7 @@ void httpSetTimerDelay(AsyncWebServerRequest *request) {
       setADSReadDelay(newDelay);
     }
     #endif
-    #ifdef ENABLE_DIGITALIN
-    else if (strcmp(timer, "digitalIn") == 0) {
-      ok = true;
-      setDigitalInUpdateDelay(newDelay);
-    }
-    #endif
-    
+        
   }
 
   if (ok) {

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -230,7 +230,6 @@ void httpGetSensorInfo(AsyncWebServerRequest *request) {
   #endif
   #ifdef ENABLE_ADS1115
   timers["ads1115Read"] = getReadADSDelay();
-  timers["ads1115Update"] = getUpdateADSDelay();
   #endif
   #ifdef ENABLE_DIGITALIN
   timers["digitalIn"] = getUpdateDigitalInDelay();
@@ -346,10 +345,6 @@ void httpSetTimerDelay(AsyncWebServerRequest *request) {
       ok = true;
       setADSReadDelay(newDelay);
     }
-    else if (strcmp(timer, "ads1115Update") == 0) {
-      ok = true;
-      setADSUpdateDelay(newDelay);
-    }        
     #endif
     #ifdef ENABLE_DIGITALIN
     else if (strcmp(timer, "digitalIn") == 0) {

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -225,9 +225,6 @@ void httpGetSensorInfo(AsyncWebServerRequest *request) {
   //Timers
   JsonObject& timers = json.createNestedObject("timers");
   timers["deltaDelay"] = getDeltaDelay();
-  #ifdef ENABLE_ONEWIRE
-  timers["oneWire"] = getOneWireReadDelay();
-  #endif
   #ifdef ENABLE_ADS1115
   timers["ads1115Read"] = getReadADSDelay();
   #endif
@@ -332,12 +329,6 @@ void httpSetTimerDelay(AsyncWebServerRequest *request) {
       ok = true;
       setDeltaDelay(newDelay);
     }
-    #ifdef ENABLE_ONEWIRE
-    else if (strcmp(timer, "oneWire") == 0) {
-      ok = true;
-      setOneWireReadDelay(newDelay);
-    }
-    #endif
     #ifdef ENABLE_ADS1115
     else if (strcmp(timer, "ads1115Read") == 0) {
       ok = true;

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include "FSConfig.h"
 #include "webSocket.h"
 #include "sigksens.h"
+#include "timer.h"
 
 // SSDP related stuff
 
@@ -223,15 +224,12 @@ void httpGetSensorInfo(AsyncWebServerRequest *request) {
 
   //Timers
   JsonObject& timers = json.createNestedObject("timers");
-
+  timers["deltaDelay"] = getDeltaDelay();
   #ifdef ENABLE_ONEWIRE
   timers["oneWire"] = getOneWireReadDelay();
   #endif
   #ifdef ENABLE_SHT30
   timers["sht30"] = getSensorSHTReadDelay();
-  #endif
-  #ifdef ENABLE_MPU
-  timers["mpu925x"] = getUpdateMPUDelay();
   #endif
   #ifdef ENABLE_ADS1115
   timers["ads1115Read"] = getReadADSDelay();
@@ -336,22 +334,20 @@ void httpSetTimerDelay(AsyncWebServerRequest *request) {
   newDelay = request->arg("delay").toInt();
 
   if (newDelay > 5) { //ostimer min delay is 5ms
-    if (strcmp(timer, "oneWire") == 0) {
+    if (strcmp(timer, "deltaDelay") == 0) {
+      ok = true;
+      setDeltaDelay(newDelay);
+    }
     #ifdef ENABLE_ONEWIRE
+    else if (strcmp(timer, "oneWire") == 0) {
       ok = true;
       setOneWireReadDelay(newDelay);
-    #endif
     }
+    #endif
     #ifdef ENABLE_SHT30
     else if (strcmp(timer, "sht30") == 0) {
       ok = true;
       setSHTReadDelay(newDelay);
-    }
-    #endif
-    #ifdef ENABLE_MPU
-    else if (strcmp(timer, "mpu925x") == 0) {
-      ok = true;
-      setMPUUpdateDelay(newDelay);
     }
     #endif
     #ifdef ENABLE_ADS1115

--- a/i2c.cpp
+++ b/i2c.cpp
@@ -184,7 +184,7 @@ void handleI2C_slow(bool &sendDelta) {
 #endif
 #ifdef ENABLE_ADS1115
   if (sensorADS1115Present) {
-    handleADS1115();
+    handleADS1115(sendDelta);
   }
 #endif
 }

--- a/i2c.cpp
+++ b/i2c.cpp
@@ -179,7 +179,7 @@ void handleI2C_slow(bool &sendDelta) {
 #endif
 #ifdef ENABLE_BMP280
   if (sensorBMP280Present) {
-    handleBMP280();  
+    handleBMP280(sendDelta);  
   }
 #endif
 #ifdef ENABLE_ADS1115

--- a/i2c.cpp
+++ b/i2c.cpp
@@ -162,10 +162,10 @@ void setupI2C(bool &need_save) {
 }
 
 
-void handleI2C() {
+void handleI2C(bool &sendDelta) {
   #ifdef ENABLE_MPU
   if (sensorMPU925XPresent) {
-    handleMPU9250();
+    handleMPU9250(sendDelta);
   }
   #endif
 }

--- a/i2c.cpp
+++ b/i2c.cpp
@@ -171,10 +171,10 @@ void handleI2C(bool &sendDelta) {
 }
 
 
-void handleI2C_slow() {
+void handleI2C_slow(bool &sendDelta) {
 #ifdef ENABLE_SHT30
   if (sensorSHT30Present) {
-    handleSHT30();  
+    handleSHT30(sendDelta);  
   }
 #endif
 #ifdef ENABLE_BMP280

--- a/i2c.h
+++ b/i2c.h
@@ -4,7 +4,7 @@
 #include "config.h"
 
 void setupI2C(bool&);
-void handleI2C();
+void handleI2C(bool&);
 void handleI2C_slow();
 
 #ifdef ENABLE_SHT30

--- a/i2c.h
+++ b/i2c.h
@@ -5,7 +5,7 @@
 
 void setupI2C(bool&);
 void handleI2C(bool&);
-void handleI2C_slow();
+void handleI2C_slow(bool&);
 
 #ifdef ENABLE_SHT30
 bool getSensorSHT30Present();

--- a/mpu9250.h
+++ b/mpu9250.h
@@ -22,11 +22,8 @@ class MPU9250SensorInfo : public SensorInfo {
 enum class MpuRunMode { mpuOff, mpuRun, calAccelGyro, calMagStart, calMagRun, calMagStop };
 
 
-uint32_t getUpdateMPUDelay();
-void setMPUUpdateDelay(uint32_t newDelay);
-
 void setupMPU9250();
-void handleMPU9250();
+void handleMPU9250(bool&);
 
 void processMPU9250();
 void updateQuaternion();

--- a/oneWire.h
+++ b/oneWire.h
@@ -14,9 +14,7 @@ class OneWireSensorInfo : public SensorInfo {
 };
 
 void setup1Wire(bool&);
-void handle1Wire(bool&);
-void setOneWireReadDelay(uint32_t);
-uint32_t getOneWireReadDelay();
+void handle1Wire(bool&, bool&);
 bool getSensorOneWirePresent();
 
 #endif

--- a/sht30.h
+++ b/sht30.h
@@ -18,9 +18,7 @@ class SHT30SensorInfo : public SensorInfo {
 
 
 void setupSHT30();
-void handleSHT30();
+void handleSHT30(bool&);
 
-uint32_t getSensorSHTReadDelay();
-void setSHTReadDelay(uint32_t newDelay);
 
 #endif

--- a/systemHz.cpp
+++ b/systemHz.cpp
@@ -55,22 +55,12 @@ void SystemHzSensorInfo::toJson(JsonObject &jsonSens) {
 }
 
 
-os_timer_t  updateHz; // once request cycle starts, this timer set so we can send when ready
-bool readyToUpdateHz = false;
 
 uint32_t systemHzCount = 0, systemHzMs = 0;
 
 float systemHz = 0;
 
-
-void interruptSystemHz(void *pArg) {
-  readyToUpdateHz = true;
-}
-
-
 void setupSystemHz(bool &need_save) {
-  os_timer_setfn(&updateHz, interruptSystemHz, NULL);
-  os_timer_arm(&updateHz, 1000, true);
   systemHzMs = millis();
   SensorInfo *tmpSensorInfo;
 
@@ -112,10 +102,8 @@ void updateSystemHz() {
 }
 
 
-void handleSystemHz() {
-  if (readyToUpdateHz) {
-    // reset interupt
-    readyToUpdateHz = false;
+void handleSystemHz(bool &sendDelta) {
+  if (sendDelta) {
     updateSystemHz();
   }
   systemHzCount++;

--- a/systemHz.h
+++ b/systemHz.h
@@ -19,6 +19,6 @@ class SystemHzSensorInfo : public SensorInfo {
 
 
 void setupSystemHz(bool&);
-void handleSystemHz();
+void handleSystemHz(bool&);
 
 #endif

--- a/timer.cpp
+++ b/timer.cpp
@@ -1,0 +1,48 @@
+extern "C" {
+#include "user_interface.h"
+}
+
+#include "config.h"
+
+#include "sigksens.h"
+
+#include "timer.h"
+
+uint32_t deltaDelay = 1000;
+os_timer_t deltaTimer;
+
+bool deltaTimerReady = false;
+
+void interruptDeltaDelay(void *pArg) {
+  deltaTimerReady = true;
+}
+
+void setupTimers() {
+  os_timer_setfn(&deltaTimer, interruptDeltaDelay, NULL);
+  Serial.print("Starting Delta timer at: ");
+  Serial.print(deltaDelay);  
+  Serial.println("ms");
+  os_timer_arm(&deltaTimer, deltaDelay, true); 
+}
+
+void handleTimers(bool &deltaReady) {
+    if (deltaTimerReady) {
+        deltaTimerReady = false;
+        deltaReady = true;
+    } 
+}
+
+
+
+uint32_t getDeltaDelay() {
+    return deltaDelay;
+}
+
+void setDeltaDelay(uint32_t newDelay) {
+  os_timer_disarm(&deltaTimer);
+  deltaDelay = newDelay;
+  Serial.print("Restarting Delta timer at: ");
+  Serial.print(newDelay);  
+  Serial.println("ms");  
+  os_timer_arm(&deltaTimer, deltaDelay, true);  
+}

--- a/timer.h
+++ b/timer.h
@@ -1,0 +1,16 @@
+#ifndef _timer_H_
+#define _timer_H_
+
+#include "config.h"
+
+#include "sigksens.h"
+
+
+
+void setupTimers();
+void handleTimers(bool &deltaReady);
+
+uint32_t getDeltaDelay();
+void setDeltaDelay(uint32_t newDelay);
+
+#endif


### PR DESCRIPTION
Replace individual timers per sensor with one global flag to have deltas sent. Reduces number of software timers running as ESP has max of 7.