### PR TITLE
Re-enable getSensorInfo

### DIFF
--- a/src/net/httpd.cpp
+++ b/src/net/httpd.cpp
@@ -254,16 +254,15 @@ void httpGetSensorInfo(AsyncWebServerRequest *request) {
   //Sensor types present
 
   //Timers
-  //JsonObject& timers = json.createNestedObject("timers");
+  JsonObject& timers = json.createNestedObject("timers");
 
-  /*
   //Sensors
   JsonArray& sensorArr = json.createNestedArray("sensors");
   
   sensorStorageForEach([&](SensorInfo* si) {
     JsonObject& tmpSens = sensorArr.createNestedObject();
     si->toJson(tmpSens);
-  }); */
+  });
 
   response->setLength();
   request->send(response);

--- a/src/services/signalK.cpp
+++ b/src/services/signalK.cpp
@@ -139,7 +139,7 @@ void sendDelta() {
   });
 
   delta.printTo(deltaText);
-  Serial.println(deltaText);
+  //Serial.println(deltaText);
   #ifdef ENABLE_WEBSOCKET_SERVER
   webSocketServer.broadcastTXT(deltaText);
   #endif


### PR DESCRIPTION
This patch simply re-enables getSensorInfo. I think it's much preferable to have the functionality there and let it break at a corner case than have essential functionality removed. Now that the different sensor types are disabled by default, it shouldn't be very likely that someone has all sensors enabled at once.

It might be that the memory usage could be reduced if all the SensorInfo member variables were `char *` instead of `String`, but this would be a sweeping change again, and this would need to be verified first by looking at the source code. It might apply only to deserializing, though.

I also disabled the debug printing of all deltas because there may be quite a few of them for some sensor types (MPU, in particular).