### PR TITLE
Add LED blinking status indication

### DIFF
--- a/SigkSens/SigkSens.ino
+++ b/SigkSens/SigkSens.ino
@@ -107,7 +107,6 @@ void setupFromJson() {
   #endif
 }
 
-
 // forward declarations
 void loop_();
 void slow_loop();
@@ -117,10 +116,11 @@ Reactduino app([] () {
   // put your setup code here, to run once:
   Serial.begin(115200);
 
+  ledBlinker.setWifiDisconnected();
+
   setupFromJson();
 
   setupFS();
-
 
   setupWifi();
   loadConfig();

--- a/SigkSens/config.h
+++ b/SigkSens/config.h
@@ -58,6 +58,11 @@ Defines
 
 #define MAX_SIGNALK_PATH_LEN 150
 
+// LED pin
+
+#define LED_PIN LED_BUILTIN
+#define LED_ACTIVE_LOW true
+
 // Digital input pins
 
 #define NUMBER_DIGITAL_INPUT 2  // set to number of elements in next two arrays...s

--- a/SigkSens/sigksens.cpp
+++ b/SigkSens/sigksens.cpp
@@ -31,3 +31,47 @@ SensorInfo* SensorStorage::find(String addr) {
 }
 
 SensorStorage sensorStorage[(int)SensorType::SensorType_MAX+1];
+
+LedBlinker::LedBlinker() {
+  pinMode(LED_PIN, OUTPUT);
+  this->setState(0);
+}
+
+void LedBlinker::setState(int newState) {
+  this->currentState = newState;
+  #ifdef LED_ACTIVE_LOW
+  digitalWrite(LED_PIN, !newState);
+  #else
+  digitalWrite(LED_PIN, newState);
+  #endif
+}
+
+void LedBlinker::flip() {
+  this->setState(!this->currentState);
+}
+
+void LedBlinker::setWifiDisconnected() {
+  app.free(this->blinker);
+  this->blinker = app.repeat(1000, [] () {
+    ledBlinker.setState(1);
+    app.delay(100, [] () {
+      ledBlinker.setState(0);
+    });
+  });
+}
+
+void LedBlinker::setWifiConnected() {
+  app.free(this->blinker);
+  this->blinker = app.repeat(1000, [] () {
+    ledBlinker.flip();
+  });
+}
+
+void LedBlinker::setServerConnected() {
+  app.free(this->blinker);
+  this->blinker = app.repeat(200, [] () {
+    ledBlinker.flip();
+  });
+}
+
+LedBlinker ledBlinker;

--- a/SigkSens/sigksens.h
+++ b/SigkSens/sigksens.h
@@ -1,6 +1,7 @@
 #ifndef _sigksens_H_
 #define _sigksens_H_
 
+#include "config.h"
 #include <Reactduino.h>
 #include <ArduinoJson.h>
 #include <map>
@@ -65,6 +66,25 @@ void SensorStorage::forEach(F&& lambda) {
     lambda(x.second);
   }
 }
+
+class LedBlinker {
+  private:
+    int currentState = 0;
+    reaction blinker = INVALID_REACTION;
+  protected:
+    void setState(int newState);
+  public:
+    void setWifiConnected();
+    void setWifiDisconnected();
+    void setServerConnected();
+    inline void setServerDisconnected() {
+      setWifiConnected();
+    }
+    void flip();
+    LedBlinker();
+};
+
+extern LedBlinker ledBlinker;
 
 extern Reactduino app;
 

--- a/SigkSens/src/net/sigKWifi.cpp
+++ b/SigkSens/src/net/sigKWifi.cpp
@@ -38,6 +38,7 @@ void setupWifi() {
   }
 
   Serial.println(F("Connected to Wifi!"));
+  ledBlinker.setWifiConnected();
 
   // Save config if needed
   if (shouldSaveConfig) {

--- a/SigkSens/src/net/webSocket.cpp
+++ b/SigkSens/src/net/webSocket.cpp
@@ -121,10 +121,12 @@ void webSocketClientEvent(WStype_t type, uint8_t * payload, size_t length) {
       signalKClientInfo.connected = false;
       app.delay(10000, &connectWebSocketClient);
       Serial.printf("[WSc] Disconnected!\n");
+      ledBlinker.setServerDisconnected();
       break;
     case WStype_CONNECTED: {
       signalKClientInfo.connected = true;
       Serial.printf("[WSc] Connected to url: %s\n", payload);
+      ledBlinker.setServerConnected();
       // send message to server when Connected
       // webSocket.sendTXT("Connected");
     }

--- a/SigkSens/src/services/signalK.cpp
+++ b/SigkSens/src/services/signalK.cpp
@@ -150,6 +150,7 @@ void sendDelta() {
   
   if (signalKClientInfo.connected) { // client
     signalKClientInfo.client.sendTXT(deltaText);
+    ledBlinker.flip();
   }
   
 }


### PR DESCRIPTION
I thought it'd be useful to be able to tell the device status more easily. I made the device LED blink according to the network status.

- Brief flashes: no wifi (shouldn't exist in practice because the device reboots whenever that happens)
- Slow blinking: wifi but no server connection
- Fast blinking: wifi and server connection
- Fast, uneven blinking: data is transmitted to the server
