### PR TITLE
make the platformio setup default to Wemos D1 Mini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,9 +12,9 @@
 src_dir = SigKSens
 
 
-[env:nodemcuv2]
+[env:d1_mini]
 platform = espressif8266
-board = nodemcuv2
+board = d1_mini
 framework = arduino
 monitor_speed = 115200
 board_build.f_cpu = 160000000L


### PR DESCRIPTION
Ho ho ho! Merry Christmas! I updated the PlatformIO setup to default to Wemos D1 Mini. There's probably no functional change but given that the D1 Mini is the reference board for SigKSens, this should reduce some potential confusion.