### PR TITLE
Add support for BME280 sensor

### DIFF
--- a/SigkSens/SigkSens.ino
+++ b/SigkSens/SigkSens.ino
@@ -14,6 +14,9 @@
 #ifdef ENABLE_BMP280
   #include "src/sensors/bmp280/bmp280.h"
 #endif
+#ifdef ENABLE_BME280
+  #include "src/sensors/bme280/bme280.h"
+#endif
 #ifdef ENABLE_ADS1115
 #include "src/sensors/ads1115/ads1115.h"
 #endif
@@ -106,6 +109,11 @@ void setupFromJson() {
   #ifdef ENABLE_BMP280
   fromJson[(int)SensorType::bmp280] =
     (fromJsonFunc)&(BMP280SensorInfo::fromJson);
+  #endif
+
+  #ifdef ENABLE_BME280
+  fromJson[(int)SensorType::bme280] =
+    (fromJsonFunc)&(BME280SensorInfo::fromJson);
   #endif
 }
 

--- a/SigkSens/config.h
+++ b/SigkSens/config.h
@@ -82,7 +82,9 @@ Defines
 #define DIGITAL_OUTPUT_NAME {"OUT1", "OUT2"}
 
 // For the BME280
-#define SEALEVELPRESSURE_HPA (1022.75) // (1013.25)
+// 1013.25 is "standard pressure", but sea level pressure changes constantly, so the Altitude measurement is
+// unlikely to ever be very accurate.
+#define SEALEVELPRESSURE_HPA (1013.25)
 
 // ADS1115 read interval
 #define ADS1115_READ_INTERVAL 50

--- a/SigkSens/config.h
+++ b/SigkSens/config.h
@@ -30,6 +30,7 @@ Feature selection
 //#define ENABLE_SHT30
 //#define ENABLE_MPU
 //#define ENABLE_BMP280
+//#define ENABLE_BME280
 //#define ENABLE_ADS1115
 
 // Services

--- a/SigkSens/config.h
+++ b/SigkSens/config.h
@@ -81,6 +81,9 @@ Defines
 #define DIGITAL_OUTPUT_PINS { 16, 15 }  // D0, D8 of Wemos)
 #define DIGITAL_OUTPUT_NAME {"OUT1", "OUT2"}
 
+// For the BME280
+#define SEALEVELPRESSURE_HPA (1022.75) // (1013.25)
+
 // ADS1115 read interval
 #define ADS1115_READ_INTERVAL 50
 

--- a/SigkSens/src/sensors/bme280/bme280.cpp
+++ b/SigkSens/src/sensors/bme280/bme280.cpp
@@ -12,8 +12,6 @@ extern "C" {
 
 #include "bme280.h"
 
-#define SEALEVELPRESSURE_HPA (1022.75) // (1013.25)
-
 BME280SensorInfo::BME280SensorInfo(String addr) {
   strcpy(address, addr.c_str());
   signalKPath[0] = "";

--- a/SigkSens/src/sensors/bme280/bme280.cpp
+++ b/SigkSens/src/sensors/bme280/bme280.cpp
@@ -1,0 +1,157 @@
+#ifdef ESP8266
+extern "C" {
+#include "user_interface.h"
+}
+#endif
+
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include <Adafruit_BME280.h>
+
+#include "../../../config.h"
+
+#include "bme280.h"
+
+#define SEALEVELPRESSURE_HPA (1022.75) // (1013.25)
+
+BME280SensorInfo::BME280SensorInfo(String addr) {
+  strcpy(address, addr.c_str());
+  signalKPath[0] = "";
+  signalKPath[1] = "";
+  signalKPath[2] = "";
+  signalKPath[3] = "";
+  attrName[0] = "tempK";
+  attrName[1] = "Pa";
+  attrName[2] = "humidity";
+  attrName[3] = "altitude";
+  type = SensorType::bme280;
+  valueJson[0] = "null";
+  valueJson[1] = "null";
+  valueJson[2] = "null";
+  valueJson[3] = "null";
+  offset[0] = 0;
+  offset[1] = 0;
+  offset[2] = 0;
+  offset[3] = 0;
+  scale[0] = 1;
+  scale[1] = 1;
+  scale[2] = 1;
+  scale[3] = 1;
+
+  isUpdated = false;
+}
+
+BME280SensorInfo::BME280SensorInfo(String addr, String path1, String path2, String path3, String path4, 
+                                   float offset0, float offset1, float offset2, float offset3,
+                                   float scale0, float scale1, float scale2, float scale3) {
+  strcpy(address, addr.c_str());
+  signalKPath[0] = path1;
+  signalKPath[1] = path2;
+  signalKPath[2] = path3;
+  signalKPath[3] = path4;
+  attrName[0] = "tempK";
+  attrName[1] = "Pa";
+  attrName[2] = "humidity";
+  attrName[3] = "altitude";
+  type = SensorType::bme280;
+  valueJson[0] = "null";
+  valueJson[1] = "null";
+  valueJson[2] = "null";
+  valueJson[3] = "null";
+  offset[0] = offset0;
+  offset[1] = offset1;
+  offset[2] = offset2;
+  offset[3] = offset3;
+  scale[0] = scale0;
+  scale[1] = scale1;
+  scale[2] = scale2;
+  scale[3] = scale3;
+
+  isUpdated = false;
+}
+
+BME280SensorInfo *BME280SensorInfo::fromJson(JsonObject &jsonSens) {
+  return new BME280SensorInfo(
+    jsonSens["address"],
+    jsonSens["attrs"][0]["signalKPath"],
+    jsonSens["attrs"][1]["signalKPath"],
+    jsonSens["attrs"][2]["signalKPath"],
+    jsonSens["attrs"][3]["signalKPath"],
+    jsonSens["attrs"][0]["offset"],
+    jsonSens["attrs"][1]["offset"],
+    jsonSens["attrs"][2]["offset"],
+    jsonSens["attrs"][3]["offset"],
+    jsonSens["attrs"][0]["scale"],
+    jsonSens["attrs"][1]["scale"],
+    jsonSens["attrs"][2]["scale"],
+    jsonSens["attrs"][3]["scale"]
+  );
+}
+
+void BME280SensorInfo::toJson(JsonObject &jsonSens) {
+  jsonSens["address"] = address;
+  jsonSens["type"] = (int)SensorType::bme280;
+  JsonArray& jsonAttrs = jsonSens.createNestedArray("attrs");
+  for (int x=0 ; x < MAX_SENSOR_ATTRIBUTES ; x++) {
+    if (strcmp(attrName[x].c_str(), "") == 0 ) {
+      break; //no more attributes
+    }
+    JsonObject& attr = jsonAttrs.createNestedObject();
+    attr["name"] = attrName[x];
+    attr["signalKPath"] = signalKPath[x];
+    attr["offset"] = offset[x];
+    attr["scale"] = scale[x];
+    attr["value"] = valueJson[x];
+  }
+}
+
+
+// sensor object
+Adafruit_BME280 bme;
+
+//Running values. (running value to reduce noise with exponential filter)
+float valuTempK = 0;
+float valuPa = 0;
+float valueHum = 0;
+float valueAlt = 0;
+
+uint16_t readBMEDelay = 25;
+
+// forward declarations
+void readBME280();
+void updateBME280();
+
+
+void setupBME280() {
+   // this calls Wire.begin() again, but that shouldn't
+  // do any harm. Hopefully.
+  bme.begin(0x76);
+  app.onRepeat(SLOW_LOOP_DELAY, readBME280);
+}
+
+void readBME280() {
+  float TempK;
+  float Pa;
+  float Hum;
+  float Alt;
+  
+  Pa = bme.readPressure();
+  TempK = bme.readTemperature() + 273.15;
+  valueHum = bme.readHumidity();
+  valueAlt = bme.readAltitude(SEALEVELPRESSURE_HPA);  
+  valuPa = ((0.05*Pa) + (0.95*valuPa));
+  valuTempK = ((0.2*TempK) + (0.8*valuTempK));
+
+  updateBME280();
+
+}
+
+void updateBME280() {
+  sensorStorage[(int)SensorType::bme280].forEach([&](SensorInfo* si) {
+    si->valueJson[0] = (valuTempK * si->scale[0] ) + si->offset[0];
+    si->valueJson[1] = (valuPa * si->scale[1] ) + si->offset[1];
+    si->valueJson[2] = (valueHum * si->scale[2] ) + si->offset[2];
+    si->valueJson[3] = (valueAlt * si->scale[3] ) + si->offset[3];
+    si->isUpdated = true;
+  });
+}

--- a/SigkSens/src/sensors/bme280/bme280.h
+++ b/SigkSens/src/sensors/bme280/bme280.h
@@ -1,0 +1,25 @@
+#ifndef _bme280_H_
+#define _bme280_H_
+
+#include "../../../sigksens.h"
+#include "../sensorStorage.h"
+
+
+class BME280SensorInfo : public SensorInfo {
+  public:
+    BME280SensorInfo(String addr);
+    BME280SensorInfo(String addr, 
+    				 String path1, String path2, String path3, String path4,
+    				 float offset0, float offset1, float offset2, float offset3, 
+    				 float scale0, float scale1, float scale2, float scale3);
+
+    static BME280SensorInfo *fromJson(JsonObject &jsonSens);
+    void toJson(JsonObject &jsonSens);
+};
+
+
+void setupBME280();
+void handleBME280(bool&);
+void interruptReadBME(void *pArg);
+void updateBME280();
+#endif

--- a/SigkSens/src/sensors/sensorType.h
+++ b/SigkSens/src/sensors/sensorType.h
@@ -11,6 +11,7 @@ enum class SensorType {
   sht30,
   mpu925x,
   bmp280,
+  bme280,
   ads1115,
   analogIn,
   digitalOut,

--- a/SigkSens/src/services/i2c.cpp
+++ b/SigkSens/src/services/i2c.cpp
@@ -23,6 +23,10 @@ extern "C" {
 #include "../sensors/bmp280/bmp280.h"
 #endif
 
+#ifdef ENABLE_BME280
+#include "../sensors/bme280/bme280.h"
+#endif
+
 #ifdef ENABLE_ADS1115
 #include "../sensors/ads1115/ads1115.h"
 #endif
@@ -95,11 +99,25 @@ void setupI2C(bool &need_save) {
   }
   #endif
 
+  #ifdef ENABLE_BME280
+  if (scanI2CAddress(0x76)) {
+    bool known = sensorStorage[(int)SensorType::bme280].find("0x76") != nullptr;
+    if (!known) {
+      Serial.print(F("New BME280 found at: 0x76 "));
+      SensorInfo *newSensor = new BME280SensorInfo("0x76");
+      sensorStorage[(int)newSensor->type].add(newSensor);
+      need_save = true;
+    }
+    setupBME280();
+  }
+  #endif
+
   #ifdef ENABLE_ADS1115
   if (scanI2CAddress(0x48)) {
     Serial.println(F("Found ADS1115 chip at 0x48"));
     bool known = sensorStorage[(int)SensorType::ads1115].find("0x48") != nullptr;
     if (!known) {
+      Serial.print(F("New ADS1115 chip found at: 0x48 "));
       SensorInfo *newSensor = new ADSSensorInfo("0x48");
       sensorStorage[(int)newSensor->type].add(newSensor);
       need_save = true;


### PR DESCRIPTION
Very similar to the BMP280, but adds humidity and altitude (although the altitude value can't be relied upon, as it needs to know current Sea Level Pressure for the current location). Thanks to @hwater for the work. (I just reviewed it and created the PR.)
Addresses Issue #79 