### PR TITLE
Added support for INA219 current sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 my_config.h
 .vscode
+.pio
 .pioenvs
 .piolibdeps
 .vscode/.browse.c_cpp.db*

--- a/SigkSens/SigkSens.ino
+++ b/SigkSens/SigkSens.ino
@@ -35,6 +35,9 @@
 #ifdef ENABLE_SYSTEMHZ
   #include "src/sensors/systemHz/systemHz.h"
 #endif
+#ifdef ENABLE_INA219
+  #include "src/sensors/ina219/ina219.h"
+#endif
 
 #include "FSConfig.h"
 
@@ -114,6 +117,11 @@ void setupFromJson() {
   #ifdef ENABLE_BME280
   fromJson[(int)SensorType::bme280] =
     (fromJsonFunc)&(BME280SensorInfo::fromJson);
+  #endif
+
+  #ifdef ENABLE_INA219
+  fromJson[(int)SensorType::ina219] =
+    (fromJsonFunc)&(INA219SensorInfo::fromJson);
   #endif
 }
 

--- a/SigkSens/config.h
+++ b/SigkSens/config.h
@@ -9,7 +9,7 @@ Feature selection
 
 // Print Deltas to Serial? when enabled deltas are also printed to Serial, to 
 // aid in debuging. If you do not want this comment this line out.
-#define ENABLE_SERIAL_DELTA
+ #define ENABLE_SERIAL_DELTA
 
 
 // To enable any of the features below, either uncomment out the row
@@ -32,6 +32,7 @@ Feature selection
 //#define ENABLE_BMP280
 //#define ENABLE_BME280
 //#define ENABLE_ADS1115
+//#define ENABLE_INA219
 
 // Services
 
@@ -105,6 +106,13 @@ Defines
 // pin is defined below:
 
 #define MPU_INTERRUPT_PIN 12 // D6 pin on Wemos D1 Mini
+
+// INA219 shunt setup
+
+#define SHUNT_AMP    200  // max ampere for shunt
+#define SHUNT_MV     75   // mV output at max amp
+#define MAX_VOLT     14.4 // max bus voltage (alternator/charge max)
+#define MAX_AMP      150  // max amp to be measured over shunt
 
 // Button configuration for resetting the device
 

--- a/SigkSens/src/sensors/ina219/Adafruit_INA219_custom.cpp
+++ b/SigkSens/src/sensors/ina219/Adafruit_INA219_custom.cpp
@@ -1,0 +1,290 @@
+
+/*!
+ * @file Adafruit_INA219_custom.cpp
+ *
+ * @mainpage Adafruit INA219 current/power monitor IC
+ *
+ * @section intro_sec Introduction
+ *
+ *  Driver for the INA219 current sensor
+ *
+ *  This is a library for the Adafruit INA219 breakout
+ *  ----> https://www.adafruit.com/product/904
+ *
+ *  Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit and open-source hardware by purchasing
+ *  products from Adafruit!
+ *
+ * @section author Author
+ *
+ * Written by Bryan Siepert and Kevin "KTOWN" Townsend for Adafruit Industries.
+ *
+ * @section license License
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
+
+#include "Arduino.h"
+#include "Adafruit_INA219_custom.h"
+#include <Wire.h>
+
+
+/*!
+ *  @brief  Instantiates a new INA219 class
+ *  @param addr the I2C address the device can be found on. Default is 0x40
+ */
+Adafruit_INA219_custom::Adafruit_INA219_custom(uint8_t addr) {
+  ina219_i2caddr = addr;
+  ina219_currentMultiplier_A = 0.0f;
+  ina219_powerMultiplier_W = 0.0f;
+}
+
+/*!
+ *  @brief  Sets up the HW (defaults to 32V and 2A for calibration values)
+ *  @param theWire the TwoWire object to use
+ *  @return true: success false: Failed to start I2C
+ */
+bool Adafruit_INA219_custom::begin(TwoWire *theWire) {
+  i2c_dev = new Adafruit_I2CDevice(ina219_i2caddr, theWire);
+
+  if (!i2c_dev->begin()) {
+    return false;
+  }
+  init();
+  return true;
+}
+
+/*!
+ *  @brief  begin I2C and set up the hardware
+ */
+void Adafruit_INA219_custom::init() {
+  // Set chip to large range config values to start
+}
+
+/*!
+ *  @brief  Checks if conversion is ready
+ *  @return return true if conversion is ready
+ */
+bool Adafruit_INA219_custom::conversionReady() {
+  uint16_t value;
+
+  Adafruit_BusIO_Register bus_voltage_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_BUSVOLTAGE, 2, MSBFIRST);
+  bus_voltage_reg.read(&value);
+
+  // Shift to the right 3 to drop CNVR and OVF and multiply by LSB
+  return (value & INA219_CNVR_MASK) != 0;
+}
+
+/*!
+ *  @brief  Gets the raw bus voltage (16-bit signed integer, so +-32767)
+ *  @return the raw bus voltage reading
+ */
+int16_t Adafruit_INA219_custom::getBusVoltage_raw() {
+  uint16_t value;
+
+  Adafruit_BusIO_Register bus_voltage_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_BUSVOLTAGE, 2, MSBFIRST);
+  bus_voltage_reg.read(&value);
+
+  // Shift to the right 3 to drop CNVR and OVF and multiply by LSB
+  return (int16_t)((value >> 3) * 4);
+}
+
+/*!
+ *  @brief  Gets the raw shunt voltage (16-bit signed integer, so +-32767)
+ *  @return the raw shunt voltage reading
+ */
+int16_t Adafruit_INA219_custom::getShuntVoltage_raw() {
+  uint16_t value;
+  Adafruit_BusIO_Register shunt_voltage_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_SHUNTVOLTAGE, 2, MSBFIRST);
+  shunt_voltage_reg.read(&value);
+  return value;
+}
+
+/*!
+ *  @brief  Gets the raw current value (16-bit signed integer, so +-32767)
+ *  @return the raw current reading
+ */
+int16_t Adafruit_INA219_custom::getCurrent_raw() {
+  uint16_t value;
+
+  // Sometimes a sharp load will reset the INA219, which will
+  // reset the cal register, meaning CURRENT and POWER will
+  // not be available ... avoid this by always setting a cal
+  // value even if it's an unfortunate extra step
+  Adafruit_BusIO_Register calibration_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CALIBRATION, 2, MSBFIRST);
+  calibration_reg.write(ina219_calValue, 2);
+
+  // Now we can safely read the CURRENT register!
+  Adafruit_BusIO_Register current_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CURRENT, 2, MSBFIRST);
+  current_reg.read(&value);
+  return value;
+}
+
+/*!
+ *  @brief  Gets the raw power value (16-bit signed integer, so +-32767)
+ *  @return raw power reading
+ */
+int16_t Adafruit_INA219_custom::getPower_raw() {
+  uint16_t value;
+
+  // Sometimes a sharp load will reset the INA219, which will
+  // reset the cal register, meaning CURRENT and POWER will
+  // not be available ... avoid this by always setting a cal
+  // value even if it's an unfortunate extra step
+  Adafruit_BusIO_Register calibration_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CALIBRATION, 2, MSBFIRST);
+  calibration_reg.write(ina219_calValue, 2);
+
+  // Now we can safely read the POWER register!
+  Adafruit_BusIO_Register power_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_POWER, 2, MSBFIRST);
+  power_reg.read(&value);
+  return value;
+}
+
+/*!
+ *  @brief  Triggers conversion
+ */
+void Adafruit_INA219_custom::triggerMeasurement() {
+  Adafruit_BusIO_Register config_reg = Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
+  Adafruit_BusIO_RegisterBits mode_bits = Adafruit_BusIO_RegisterBits(&config_reg, 3, 0);
+  mode_bits.write(INA219_CONFIG_MODE_SANDBVOLT_TRIGGERED);
+}
+
+/*!
+ *  @brief  Gets the shunt voltage in mV (so +-327mV)
+ *  @return the shunt voltage converted to millivolts
+ */
+float Adafruit_INA219_custom::getShuntVoltage_mV() {
+  int16_t value;
+  value = getShuntVoltage_raw();
+  return value * 0.01;
+}
+
+/*!
+ *  @brief  Gets the shunt voltage in volts
+ *  @return the bus voltage converted to volts
+ */
+float Adafruit_INA219_custom::getBusVoltage_V() {
+  int16_t value = getBusVoltage_raw();
+  return value * 0.001;
+}
+
+/*!
+ *  @brief  Gets the current value in mA, taking into account the
+ *          config settings and current LSB
+ *  @return the current reading convereted to milliamps
+ */
+float Adafruit_INA219_custom::getCurrent_A() {
+  float valueDec = getCurrent_raw();
+  valueDec *= ina219_currentMultiplier_A;
+  return valueDec;
+}
+
+/*!
+ *  @brief  Gets the power value in mW, taking into account the
+ *          config settings and current LSB
+ *  @return power reading converted to milliwatts
+ */
+float Adafruit_INA219_custom::getPower_W() {
+  float valueDec = getPower_raw();
+  valueDec *= ina219_powerMultiplier_W;
+  return valueDec;
+}
+
+/*!
+ *  @brief  Set power save mode according to parameters
+ *  @param  on
+ *          boolean value
+ */
+void Adafruit_INA219_custom::powerSave(bool on) {
+  Adafruit_BusIO_Register config_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
+
+  Adafruit_BusIO_RegisterBits mode_bits =
+      Adafruit_BusIO_RegisterBits(&config_reg, 3, 0);
+  if (on) {
+    mode_bits.write(INA219_CONFIG_MODE_POWERDOWN);
+  } else {
+    mode_bits.write(INA219_CONFIG_MODE_SANDBVOLT_TRIGGERED);
+  }
+}
+
+/*!
+ *  @brief set device to alibration which uses the highest precision for
+ *     current measurement (0.1mA), at the expense of
+ *     only supporting 16V at 400mA max.
+ */
+bool Adafruit_INA219_custom::setCalibration(float shunt_A, float shunt_mV, float max_V, float max_A) {
+  // scale shunt values to working range
+  float scaled_mV = max_A/shunt_A * shunt_mV;
+
+  // set optimal PGA gain
+  uint16_t config_gain;
+  if (scaled_mV <= 40)
+    config_gain = INA219_CONFIG_GAIN_1_40MV; // Gain 1, 40mV Range
+  else if (scaled_mV <= 80)
+    config_gain = INA219_CONFIG_GAIN_2_80MV;  // Gain 2, 80mV Range
+  else if (scaled_mV <= 160)
+    config_gain = INA219_CONFIG_GAIN_4_160MV; // Gain 4, 160mV Range
+  else if (scaled_mV <= 320)
+    config_gain = INA219_CONFIG_GAIN_8_320MV; // Gain 8, 320mV Range
+  else
+    return false;
+
+  // set ADC range
+  uint16_t config_range;
+  if (max_V <= 16)
+    config_range = INA219_CONFIG_BVOLTAGERANGE_16V; // 0-16V Range
+  else if (max_V <= 32)
+    config_range = INA219_CONFIG_BVOLTAGERANGE_32V; // 0-32V Range
+  else
+    return false; // out of range
+
+  // calculate minimum LSB for adc
+  float shunt_r = shunt_mV/shunt_A/1000.;
+  float LSB_min = max_A/32768;
+  
+  // round LSB to nearest factor 5
+  float LSB_factor = pow(10.0, 1-ceil(log10(LSB_min/5)))/5;
+  float LSB_round = ceil(LSB_min * LSB_factor) / LSB_factor;
+  
+  // Set shunt calibration value
+  ina219_calValue = truncf(0.04096/(LSB_round*shunt_r));
+  
+  // Set multipliers to convert raw current/power values
+  ina219_currentMultiplier_A = LSB_round;
+  ina219_powerMultiplier_W = 20. * LSB_round;
+
+  // Set Calibration register to 'Cal' calculated above
+  Adafruit_BusIO_Register calibration_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CALIBRATION, 2, MSBFIRST);
+  calibration_reg.write(ina219_calValue, 2);
+  // Set Config register to take into account the settings above
+  uint16_t config = config_range |
+                    config_gain | INA219_CONFIG_BADCRES_12BIT |
+                    INA219_CONFIG_BADCRES_12BIT_128S_69MS;
+
+  Adafruit_BusIO_Register config_reg =
+      Adafruit_BusIO_Register(i2c_dev, INA219_REG_CONFIG, 2, MSBFIRST);
+  config_reg.write(config, 2);
+
+  Serial.print("INA219: ");
+  Serial.print(shunt_A,0);
+  Serial.print("A, ");
+  Serial.print(shunt_mV,0);
+  Serial.print("mV, ");
+  Serial.print(shunt_r*1000,3);
+  Serial.print("mOhm, ");
+  Serial.print(LSB_round*1000,2);
+  Serial.print("mA/bit, ");
+  Serial.print(ina219_calValue);
+  Serial.println("cal value");
+  return true;
+}

--- a/SigkSens/src/sensors/ina219/Adafruit_INA219_custom.h
+++ b/SigkSens/src/sensors/ina219/Adafruit_INA219_custom.h
@@ -1,0 +1,185 @@
+/*!
+ * @file Adafruit_INA219_custom.h
+ *
+ * This is a library for the Adafruit INA219 breakout board
+ * ----> https://www.adafruit.com/product/904
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Written by Bryan Siepert and Kevin "KTOWN" Townsend for Adafruit Industries.
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ * Edited by Njål Brekke for use with large external shunts
+ * + Custom values for shunts
+ * + Current in A insted of mA
+ */
+
+#ifndef _LIB_ADAFRUIT_INA219_CUSTOM_
+#define _LIB_ADAFRUIT_INA219_CUSTOM_
+
+#include "Arduino.h"
+#include <Adafruit_BusIO_Register.h>
+#include <Adafruit_I2CDevice.h>
+#include <Wire.h>
+
+/** default I2C address **/
+#define INA219_ADDRESS (0x40) // 1000000 (A0+A1=GND)
+
+/** read **/
+#define INA219_READ (0x01)
+
+/*=========================================================================
+    CONFIG REGISTER (R/W)
+**************************************************************************/
+
+/** config register address **/
+#define INA219_REG_CONFIG (0x00)
+
+/** reset bit **/
+#define INA219_CONFIG_RESET (0x8000) // Reset Bit
+
+/** mask for bus voltage range **/
+#define INA219_CONFIG_BVOLTAGERANGE_MASK (0x2000) // Bus Voltage Range Mask
+
+/** bus voltage range values **/
+enum {
+  INA219_CONFIG_BVOLTAGERANGE_16V = (0x0000), // 0-16V Range
+  INA219_CONFIG_BVOLTAGERANGE_32V = (0x2000), // 0-32V Range
+};
+
+/** mask for conversion ready bit **/
+#define INA219_CNVR_MASK 1<<1
+
+/** mask for gain bits **/
+#define INA219_CONFIG_GAIN_MASK (0x1800) // Gain Mask
+
+/** values for gain bits **/
+enum {
+  INA219_CONFIG_GAIN_1_40MV = (0x0000),  // Gain 1, 40mV Range
+  INA219_CONFIG_GAIN_2_80MV = (0x0800),  // Gain 2, 80mV Range
+  INA219_CONFIG_GAIN_4_160MV = (0x1000), // Gain 4, 160mV Range
+  INA219_CONFIG_GAIN_8_320MV = (0x1800), // Gain 8, 320mV Range
+};
+
+/** mask for bus ADC resolution bits **/
+#define INA219_CONFIG_BADCRES_MASK (0x0780)
+
+/** values for bus ADC resolution **/
+enum {
+  INA219_CONFIG_BADCRES_9BIT = (0x0000),  // 9-bit bus res = 0..511
+  INA219_CONFIG_BADCRES_10BIT = (0x0080), // 10-bit bus res = 0..1023
+  INA219_CONFIG_BADCRES_11BIT = (0x0100), // 11-bit bus res = 0..2047
+  INA219_CONFIG_BADCRES_12BIT = (0x0180), // 12-bit bus res = 0..4097
+  INA219_CONFIG_BADCRES_12BIT_2S_1060US =
+      (0x0480), // 2 x 12-bit bus samples averaged together
+  INA219_CONFIG_BADCRES_12BIT_4S_2130US =
+      (0x0500), // 4 x 12-bit bus samples averaged together
+  INA219_CONFIG_BADCRES_12BIT_8S_4260US =
+      (0x0580), // 8 x 12-bit bus samples averaged together
+  INA219_CONFIG_BADCRES_12BIT_16S_8510US =
+      (0x0600), // 16 x 12-bit bus samples averaged together
+  INA219_CONFIG_BADCRES_12BIT_32S_17MS =
+      (0x0680), // 32 x 12-bit bus samples averaged together
+  INA219_CONFIG_BADCRES_12BIT_64S_34MS =
+      (0x0700), // 64 x 12-bit bus samples averaged together
+  INA219_CONFIG_BADCRES_12BIT_128S_69MS =
+      (0x0780), // 128 x 12-bit bus samples averaged together
+
+};
+
+/** mask for shunt ADC resolution bits **/
+#define INA219_CONFIG_SADCRES_MASK                                             \
+  (0x0078) // Shunt ADC Resolution and Averaging Mask
+
+/** values for shunt ADC resolution **/
+enum {
+  INA219_CONFIG_SADCRES_9BIT_1S_84US = (0x0000),   // 1 x 9-bit shunt sample
+  INA219_CONFIG_SADCRES_10BIT_1S_148US = (0x0008), // 1 x 10-bit shunt sample
+  INA219_CONFIG_SADCRES_11BIT_1S_276US = (0x0010), // 1 x 11-bit shunt sample
+  INA219_CONFIG_SADCRES_12BIT_1S_532US = (0x0018), // 1 x 12-bit shunt sample
+  INA219_CONFIG_SADCRES_12BIT_2S_1060US =
+      (0x0048), // 2 x 12-bit shunt samples averaged together
+  INA219_CONFIG_SADCRES_12BIT_4S_2130US =
+      (0x0050), // 4 x 12-bit shunt samples averaged together
+  INA219_CONFIG_SADCRES_12BIT_8S_4260US =
+      (0x0058), // 8 x 12-bit shunt samples averaged together
+  INA219_CONFIG_SADCRES_12BIT_16S_8510US =
+      (0x0060), // 16 x 12-bit shunt samples averaged together
+  INA219_CONFIG_SADCRES_12BIT_32S_17MS =
+      (0x0068), // 32 x 12-bit shunt samples averaged together
+  INA219_CONFIG_SADCRES_12BIT_64S_34MS =
+      (0x0070), // 64 x 12-bit shunt samples averaged together
+  INA219_CONFIG_SADCRES_12BIT_128S_69MS =
+      (0x0078), // 128 x 12-bit shunt samples averaged together
+};
+
+/** mask for operating mode bits **/
+#define INA219_CONFIG_MODE_MASK (0x0007) // Operating Mode Mask
+
+/** values for operating mode **/
+enum {
+  INA219_CONFIG_MODE_POWERDOWN = 0x00,       /**< power down */
+  INA219_CONFIG_MODE_SVOLT_TRIGGERED = 0x01, /**< shunt voltage triggered */
+  INA219_CONFIG_MODE_BVOLT_TRIGGERED = 0x02, /**< bus voltage triggered */
+  INA219_CONFIG_MODE_SANDBVOLT_TRIGGERED =
+      0x03,                         /**< shunt and bus voltage triggered */
+  INA219_CONFIG_MODE_ADCOFF = 0x04, /**< ADC off */
+  INA219_CONFIG_MODE_SVOLT_CONTINUOUS = 0x05, /**< shunt voltage continuous */
+  INA219_CONFIG_MODE_BVOLT_CONTINUOUS = 0x06, /**< bus voltage continuous */
+  INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS =
+      0x07, /**< shunt and bus voltage continuous */
+};
+
+/** shunt voltage register **/
+#define INA219_REG_SHUNTVOLTAGE (0x01)
+
+/** bus voltage register **/
+#define INA219_REG_BUSVOLTAGE (0x02)
+
+/** power register **/
+#define INA219_REG_POWER (0x03)
+
+/** current register **/
+#define INA219_REG_CURRENT (0x04)
+
+/** calibration register **/
+#define INA219_REG_CALIBRATION (0x05)
+
+/*!
+ *   @brief  Class that stores state and functions for interacting with INA219
+ *  current/power monitor IC
+ */
+class Adafruit_INA219_custom {
+public:
+  Adafruit_INA219_custom(uint8_t addr = INA219_ADDRESS);
+  bool begin(TwoWire *theWire = &Wire);
+  bool setCalibration(float shunt_A, float shunt_mV, float max_V, float max_A);
+  void triggerMeasurement();
+  bool conversionReady();
+  float getBusVoltage_V();
+  float getShuntVoltage_mV();
+  float getCurrent_A();
+  float getPower_W();
+  void powerSave(bool on);
+
+protected:
+  Adafruit_I2CDevice *i2c_dev = NULL;
+
+  uint8_t ina219_i2caddr = -1;
+  uint32_t ina219_calValue;
+  // The following multipliers are used to convert raw current and power
+  // values to mA and mW, taking into account the current config settings
+  float ina219_currentMultiplier_A;
+  float ina219_powerMultiplier_W;
+
+  void init();
+  int16_t getBusVoltage_raw();
+  int16_t getShuntVoltage_raw();
+  int16_t getCurrent_raw();
+  int16_t getPower_raw();
+};
+
+#endif

--- a/SigkSens/src/sensors/ina219/README.md
+++ b/SigkSens/src/sensors/ina219/README.md
@@ -1,0 +1,5 @@
+
+http://10.0.2.18/getSensorInfo
+http://10.0.2.18/setSensorPath?address=0x40&attrName=Current(A)&path=electrical.batteries.forbruk.current
+http://10.0.2.18/setSensorPath?address=0x40&attrName=Voltage(V)&path=electrical.batteries.forbruk.voltage
+http://10.0.2.5/setSensorAttr?address=0x40&attrName=Current(A)&offset=0.015

--- a/SigkSens/src/sensors/ina219/ina219.cpp
+++ b/SigkSens/src/sensors/ina219/ina219.cpp
@@ -1,0 +1,133 @@
+#ifdef ESP8266
+extern "C" {
+#include "user_interface.h"
+}
+#endif
+
+#include "Adafruit_INA219_custom.h"
+
+#include "../../../config.h"
+
+#include "ina219.h"
+
+INA219SensorInfo::INA219SensorInfo(String addr) {
+  strcpy(address, addr.c_str());
+  signalKPath[0] = String("electrical.batteries.") + String(myHostname) + String(".current");
+  signalKPath[1] = String("electrical.batteries.") + String(myHostname) + String(".voltage");
+  attrName[0] = "Current(A)";
+  attrName[1] = "Voltage(V)";
+  type = SensorType::ina219;
+  valueJson[0] = "null";
+  valueJson[1] = "null";
+  offset[0] = 0;
+  offset[1] = 0;
+  scale[0] = 1;
+  scale[1] = 1;
+
+  isUpdated = false;
+}
+
+INA219SensorInfo::INA219SensorInfo(
+    String addr, String path1, String path2, float offset0, float offset1, float scale0, float scale1) {
+  strcpy(address, addr.c_str());
+  signalKPath[0] = path1;
+  signalKPath[1] = path2;
+  attrName[0] = "Current(A)";
+  attrName[1] = "Voltage(V)";
+  type = SensorType::ina219;
+  valueJson[0] = "null";
+  valueJson[1] = "null";
+  offset[0] = offset0;
+  offset[1] = offset1;
+  scale[0] = scale0;
+  scale[1] = scale1;
+
+  isUpdated = false;
+}
+
+INA219SensorInfo *INA219SensorInfo::fromJson(JsonObject &jsonSens) {
+  return new INA219SensorInfo(
+    jsonSens["address"],
+    jsonSens["attrs"][0]["signalKPath"],
+    jsonSens["attrs"][1]["signalKPath"],
+    jsonSens["attrs"][0]["offset"],
+    jsonSens["attrs"][1]["offset"],
+    jsonSens["attrs"][0]["scale"],
+    jsonSens["attrs"][1]["scale"]
+  );
+}
+
+void INA219SensorInfo::toJson(JsonObject &jsonSens) {
+  jsonSens["address"] = address;
+  jsonSens["type"] = (int)SensorType::ina219;
+  JsonArray& jsonAttrs = jsonSens.createNestedArray("attrs");
+  for (int x=0 ; x < MAX_SENSOR_ATTRIBUTES ; x++) {
+    if (strcmp(attrName[x].c_str(), "") == 0 ) {
+      break; //no more attributes
+    }
+    JsonObject& attr = jsonAttrs.createNestedObject();
+    attr["name"] = attrName[x];
+    attr["signalKPath"] = signalKPath[x];
+    attr["offset"] = offset[x];
+    attr["scale"] = scale[x];
+    attr["value"] = valueJson[x];
+  }
+}
+
+// sensor object
+Adafruit_INA219_custom ina219;
+
+//Running values. (running value to reduce noise with exponential filter)
+float valueCurrent = 0;
+float valueVoltage = 0;
+
+// forward declarations
+void readINA219();
+void updateINA219();
+
+void setupINA219() {
+  Serial.println(F("Starting INA219 sensor"));
+  if (!ina219.begin()) {
+    Serial.println(F("Failed to connect to INA219"));
+    return;
+  }
+  if (!ina219.setCalibration(SHUNT_AMP, SHUNT_MV, MAX_VOLT, MAX_AMP)) {
+    Serial.println(F("Failed to configure INA219"));
+    return;
+  }
+  app.onRepeat(SLOW_LOOP_DELAY, readINA219);
+  Serial.println(F("INA219 ready"));
+}
+
+void readINA219() {
+  if (!ina219.conversionReady()) {
+    // if no new measurements are ready, trigger new and return
+    ina219.triggerMeasurement();
+    return;
+  }
+
+  float current;
+  float voltage;
+  float power;
+  float v_shunt;
+  
+  current = ina219.getCurrent_A();
+  voltage = ina219.getBusVoltage_V();
+  power = ina219.getPower_W();
+  v_shunt = ina219.getShuntVoltage_mV();
+  ina219.triggerMeasurement();
+
+  const float kf = 0.5;//0.95;
+  valueCurrent = ((1-kf)*current) + (kf*valueCurrent);
+  valueVoltage = ((1-kf)*voltage) + (kf*valueVoltage);
+
+  updateINA219();
+}
+
+void updateINA219() {
+  sensorStorage[(int)SensorType::ina219].forEach([&](SensorInfo* si) {
+    si->valueJson[0] = (valueCurrent * si->scale[0] ) + si->offset[0];
+    si->valueJson[1] = (valueVoltage * si->scale[1] ) + si->offset[1];
+    si->isUpdated = true;
+  });
+}

--- a/SigkSens/src/sensors/ina219/ina219.h
+++ b/SigkSens/src/sensors/ina219/ina219.h
@@ -1,0 +1,21 @@
+#ifndef _ina219_H_
+#define _ina219_H_
+
+#include "../../../sigksens.h"
+#include "../sensorStorage.h"
+
+
+class INA219SensorInfo : public SensorInfo {
+  public:
+    INA219SensorInfo(String addr);
+    INA219SensorInfo(String addr, String path1, String path2, float offset0, float offset1, float scale0, float scale1);
+
+    static INA219SensorInfo *fromJson(JsonObject &jsonSens);
+    void toJson(JsonObject &jsonSens);
+};
+
+
+void setupINA219();
+void handleINA219(bool&);
+void updateINA219();
+#endif

--- a/SigkSens/src/sensors/sensorType.h
+++ b/SigkSens/src/sensors/sensorType.h
@@ -15,7 +15,8 @@ enum class SensorType {
   ads1115,
   analogIn,
   digitalOut,
-  SensorType_MAX = digitalOut  // update this if you add items!
+  ina219,
+  SensorType_MAX = ina219  // update this if you add items!
 };
 
 #endif

--- a/SigkSens/src/services/i2c.cpp
+++ b/SigkSens/src/services/i2c.cpp
@@ -31,6 +31,9 @@ extern "C" {
 #include "../sensors/ads1115/ads1115.h"
 #endif
 
+#ifdef ENABLE_INA219
+#include "../sensors/ina219/ina219.h"
+#endif
 
 bool scanI2CAddress(uint8_t address) {
   uint8_t errorCode;
@@ -123,6 +126,19 @@ void setupI2C(bool &need_save) {
       need_save = true;
     }    
     setupADS1115();
+  }
+  #endif
+
+  #ifdef ENABLE_INA219
+  if (scanI2CAddress(0x40)) {
+    bool known = sensorStorage[(int)SensorType::ina219].find("0x40") != nullptr;
+    if (!known) {
+      Serial.print(F("New INA219 found at: 0x40 "));
+      SensorInfo *newSensor = new INA219SensorInfo("0x40");
+      sensorStorage[(int)newSensor->type].add(newSensor);
+      need_save = true;
+    }
+    setupINA219();
   }
   #endif
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,13 +29,14 @@ lib_deps =
     DNSServer
     https://github.com/tzapu/WiFiManager#bbe984c93b71601aad9f50f765ba9a255478bff3
     ESP8266WebServer
-    ArduinoJson
+    ArduinoJson@~5.13
     WebSockets
     ESPAsyncTCP
     ESP Async WebServer
     Adafruit ADS1X15
     Adafruit Unified Sensor
     Adafruit BMP280 Library
+    Adafruit BME280 Library
     OneWire
     DallasTemperature
 
@@ -53,13 +54,14 @@ lib_deps =
     https://github.com/tzapu/WiFiManager#bbe984c93b71601aad9f50f765ba9a255478bff3
     ESPmDNS
     marian-craciunescu/uSSDP-ESP32
-    ArduinoJson
+    ArduinoJson@~5.13
     WebSockets
     me-no-dev/AsyncTCP#idf-update
     me-no-dev/ESPAsyncWebServer
     Adafruit ADS1X15
     Adafruit Unified Sensor
     Adafruit BMP280 Library
+    Adafruit BME280 Library
     OneWire
     DallasTemperature
 


### PR DESCRIPTION
Added support for the INA219 current sensor for use with external shunt.

The adafruit INA219 library had to be customized since it did not allow for changing the shunt values. Since it had some important members set as private (and not protected), the source had to be changed instead of creating a derived class.

Tested on a 200A 75mV shunt, and seems to be working fine on the lab power-supply, will install in boat soon.

Future work:
- Add support for more INA219s, the chip can be configured for up to 16 different I2C addresses.